### PR TITLE
feat(listings): add category/tags taxonomy and discovery filters

### DIFF
--- a/backend/src/models/Listing.ts
+++ b/backend/src/models/Listing.ts
@@ -12,6 +12,8 @@ const ListingSchema = new Schema({
   mime: String,
   size: Number,
   priceLamports: { type: Number, required: true, index: true },
+  category: { type: String, index: true },
+  tags: { type: [String], index: true },
 
   // File metadata (extracted before encryption)
   metadata: {
@@ -35,5 +37,7 @@ const ListingSchema = new Schema({
 ListingSchema.index({ sellerWallet: 1, createdAt: -1 });
 ListingSchema.index({ createdAt: -1 });
 ListingSchema.index({ priceLamports: 1, createdAt: -1 });
+ListingSchema.index({ category: 1, createdAt: -1 });
+ListingSchema.index({ tags: 1, createdAt: -1 });
 
 export default model('Listing', ListingSchema);

--- a/storacha-market-ui/src/app/create/page.tsx
+++ b/storacha-market-ui/src/app/create/page.tsx
@@ -17,6 +17,8 @@ export default function CreatePage() {
   const [description, setDescription] = useState<string>('')
   const [preview, setPreview] = useState<string>('')
   const [price, setPrice] = useState<string>('0.01') // SOL
+  const [category, setCategory] = useState<string>('')
+  const [tagsText, setTagsText] = useState<string>('')
   const [loading, setLoading] = useState(false)
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -80,6 +82,7 @@ export default function CreatePage() {
       // Convert SOL to lamports
       const priceLamports = Math.floor(parseFloat(price) * 1_000_000_000)
 
+      const tags = Array.from(new Set(tagsText.split(',').map(t => t.trim().toLowerCase()).filter(t => t.length > 0))).slice(0, 10)
       const r = await api.post('/listings/create', {
         sellerWallet: publicKey.toBase58(),
         filename: file.name,
@@ -88,7 +91,9 @@ export default function CreatePage() {
         preview: preview || undefined,
         mime: file.type || 'application/octet-stream',
         base64File,
-        priceLamports
+        priceLamports,
+        category: category.trim() ? category.trim().toLowerCase() : undefined,
+        tags
       })
       showToast(`Listing created successfully! CID: ${r.data.cid.substring(0, 8)}...`, 'success')
 
@@ -99,6 +104,8 @@ export default function CreatePage() {
         setDescription('')
         setPreview('')
         setPrice('0.01')
+        setCategory('')
+        setTagsText('')
         // Reset file input
         const fileInput = document.getElementById('file') as HTMLInputElement
         if (fileInput) fileInput.value = ''
@@ -127,6 +134,33 @@ export default function CreatePage() {
             onChange={e => setName(e.target.value)}
             className="mt-2 bg-black/40 border-purple-500/30 text-white placeholder:text-gray-500"
           />
+        </div>
+
+        <div>
+          <Label htmlFor="category" className="text-sm font-semibold text-purple-300">
+            Category
+          </Label>
+          <Input
+            id="category"
+            placeholder="e.g. images, documents, audio"
+            value={category}
+            onChange={e => setCategory(e.target.value)}
+            className="mt-2 bg-black/40 border-purple-500/30 text-white placeholder:text-gray-500"
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="tags" className="text-sm font-semibold text-purple-300">
+            Tags (comma-separated)
+          </Label>
+          <Input
+            id="tags"
+            placeholder="e.g. nature, piano, pdf"
+            value={tagsText}
+            onChange={e => setTagsText(e.target.value)}
+            className="mt-2 bg-black/40 border-purple-500/30 text-white placeholder:text-gray-500"
+          />
+          <p className="text-xs text-purple-400/60 mt-2">Up to 10 tags</p>
         </div>
 
         <div>

--- a/storacha-market-ui/src/app/page.tsx
+++ b/storacha-market-ui/src/app/page.tsx
@@ -1,10 +1,26 @@
 'use client'
 import useSWR from 'swr'
 import { api } from '@/lib/api'
+import { useState, useMemo } from 'react'
 import ListingCard from '@/components/listing-card'
 
 export default function Page() {
-  const { data, isLoading } = useSWR('listings', () => api.get('/listings').then(r => r.data))
+  const [q, setQ] = useState('')
+  const [category, setCategory] = useState('')
+  const [tagsText, setTagsText] = useState('')
+  const [sort, setSort] = useState('recent')
+
+  const query = useMemo(() => {
+    const params = new URLSearchParams()
+    if (q.trim()) params.set('q', q.trim())
+    if (category.trim()) params.set('category', category.trim().toLowerCase())
+    const tags = Array.from(new Set(tagsText.split(',').map(t => t.trim().toLowerCase()).filter(Boolean))).slice(0, 10)
+    if (tags.length) params.set('tags', tags.join(','))
+    if (sort) params.set('sort', sort)
+    return params.toString()
+  }, [q, category, tagsText, sort])
+
+  const { data, isLoading } = useSWR(['listings', query], () => api.get(`/listings${query ? `?${query}` : ''}`).then(r => r.data))
 
   return (
     <main className="mx-auto max-w-7xl">
@@ -59,6 +75,37 @@ export default function Page() {
           <div>
             <h2 className="text-2xl font-bold text-white mb-1">ACTIVE LISTINGS</h2>
             <p className="text-purple-400/60 font-mono text-sm">Browse the marketplace</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              placeholder="Search"
+              value={q}
+              onChange={e => setQ(e.target.value)}
+              className="px-3 py-2 rounded bg-black/40 border border-purple-500/30 text-white placeholder:text-purple-300/50"
+            />
+            <input
+              placeholder="Category"
+              value={category}
+              onChange={e => setCategory(e.target.value)}
+              className="px-3 py-2 rounded bg-black/40 border border-purple-500/30 text-white placeholder:text-purple-300/50"
+            />
+            <input
+              placeholder="Tags (comma)"
+              value={tagsText}
+              onChange={e => setTagsText(e.target.value)}
+              className="px-3 py-2 rounded bg-black/40 border border-purple-500/30 text-white placeholder:text-purple-300/50"
+            />
+            <select
+              value={sort}
+              onChange={e => setSort(e.target.value)}
+              className="px-3 py-2 rounded bg-black/40 border border-purple-500/30 text-white"
+            >
+              <option value="recent">Recent</option>
+              <option value="price_asc">Price ↑</option>
+              <option value="price_desc">Price ↓</option>
+              <option value="rating_desc">Rating ↓</option>
+              <option value="rating_asc">Rating ↑</option>
+            </select>
           </div>
         </div>
 


### PR DESCRIPTION
Closes #9 

- Adds listing taxonomy with `category` and `tags` to improve discovery.
- Extends `GET /api/listings` with search, category/tags filters, price range, and sorting.
- Updates Create form to capture Category and Tags.
- Adds homepage filter bar (search, category, tags, sort) wired to the API.