### PR TITLE
feat(auth): issue short-lived JWT after wallet verification; add auth…

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,13 +20,15 @@
 		"sharp": "^0.33.5",
 		"tweetnacl": "^1.0.3",
 		"uuid": "^13.0.0",
-		"validator": "^13.15.0"
+		"validator": "^13.15.0",
+		"jsonwebtoken": "^9.0.2"
 	},
 	"devDependencies": {
 		"@types/cors": "^2.8.19",
 		"@types/express": "^5.0.3",
 		"@types/libsodium-wrappers": "^0.7.14",
 		"@types/node": "^24.9.1",
+		"@types/jsonwebtoken": "^9.0.6",
 		"@vercel/node": "^3.0.0",
 		"ts-node-dev": "^2.0.0",
 		"tsx": "^4.20.6",

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,82 @@
+import type { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+
+type JwtPayload = {
+  sub: string
+  verified: boolean
+  iat?: number
+  exp?: number
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        wallet: string
+      }
+    }
+  }
+}
+
+function parseCookies(req: Request): Record<string, string> {
+  const header = req.headers.cookie
+  if (!header) return {}
+  const out: Record<string, string> = {}
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=')
+    if (idx > -1) {
+      const k = part.slice(0, idx).trim()
+      const v = decodeURIComponent(part.slice(idx + 1))
+      out[k] = v
+    }
+  }
+  return out
+}
+
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  try {
+    const cookies = parseCookies(req)
+    const token = cookies['auth_token']
+    if (!token) {
+      return res.status(401).json({ error: 'Authentication required' })
+    }
+    const secret = process.env.JWT_SECRET
+    if (!secret) {
+      return res.status(500).json({ error: 'Server configuration missing' })
+    }
+    const payload = jwt.verify(token, secret) as JwtPayload
+    if (!payload?.sub || !payload.verified) {
+      return res.status(401).json({ error: 'Invalid token' })
+    }
+    req.user = { wallet: payload.sub }
+    return next()
+  } catch (e: any) {
+    return res.status(401).json({ error: 'Invalid or expired token' })
+  }
+}
+
+export function optionalAuth(req: Request, res: Response, next: NextFunction) {
+  try {
+    const cookies = parseCookies(req)
+    const token = cookies['auth_token']
+    const secret = process.env.JWT_SECRET
+    if (token && secret) {
+      const payload = jwt.verify(token, secret) as JwtPayload
+      if (payload?.sub && payload.verified) {
+        req.user = { wallet: payload.sub }
+      }
+    }
+  } catch {}
+  return next()
+}
+
+export function clearAuthCookie(res: Response) {
+  const isProd = process.env.NODE_ENV === 'production'
+  res.clearCookie('auth_token', {
+    httpOnly: true,
+    secure: isProd,
+    sameSite: 'lax',
+    path: '/',
+  })
+}
+


### PR DESCRIPTION
### Summary

* Improves UX by issuing a short-lived JWT session after wallet verification to avoid repeated signature prompts.
* JWT is used only for **non-sensitive** actions; sensitive operations still require fresh signatures.

### Changes

* **JWT issuance**

  * `POST /api/auth/verify-wallet` now issues a 15-minute JWT and sets it as an HttpOnly cookie (`auth_token`).
* **Auth middleware**

  * Adds `requireAuth` (and helpers) to validate JWT and attach `req.user`.
* **Route protection**

  * `GET /api/auth/purchase-history/:wallet` now requires a valid JWT and enforces wallet ownership.
* **Disconnect**

  * `POST /api/auth/disconnect` clears the `auth_token` cookie.
* **Dependencies**

  * Adds `jsonwebtoken` and `@types/jsonwebtoken`.
* **CORS**

  * Uses existing credential-enabled CORS setup.

### Security

* Short-lived token (default 15 minutes).
* HttpOnly cookie, `SameSite=Lax`, `Secure` in production.
* JWT includes `sub` (wallet) and `verified`.
* Does **not** bypass sensitive endpoints (payments, listing creation, delivery still require signatures).

### Configuration

* `JWT_SECRET` (required)
* `JWT_EXP_MINUTES` (optional, default: 15)

